### PR TITLE
Remove ability to close modal when overlay is clicked

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -109,7 +109,7 @@
       </div>
     </div>
     <div class="modal" id="connection-error-modal" aria-hidden="true">
-      <div class="modal__overlay" tabindex="-1" data-micromodal-close>
+      <div class="modal__overlay" tabindex="-1">
         <div class="modal__container" aria-modal="true" aria-labelledby="error-modal" >
           <header class="modal__header">
             <h2 class="modal__title" id="error-modal">OOPS! Something went wrong!</h2>


### PR DESCRIPTION
**What (if any) features are you implementing?**
- NA
- FIX: Remove ability to close modal when overlay is clicked

**What (if anything) did you refactor?**
- NA

**Were there any issues that arose?**
- User could close the micromodal and it would allow them continue using the application without connection. 

**Any other comments, questions, or concerns?**
- NA
